### PR TITLE
Allow bot account to run release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,10 @@ jobs:
       github.event.issue.pull_request != null &&
       startsWith(github.event.issue.title, 'Release:') &&
       !contains(github.event.issue.labels.*.name, 'locked') &&
-      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+      (
+        contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association) ||
+        github.event.comment.user.login == '1gtm-app[bot]'
+      )
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Summary
- Allows the `1gtm-app[bot]` GitHub App account to trigger the release workflow, in addition to OWNER/MEMBER author associations.

Cherry-picks kubevault/CHANGELOG@5add557ff24b20cc3be46f2b95dc34500ac6386d.